### PR TITLE
Downgrade http dependency for Dart 2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  http: ^1.1.0
+  http: ^0.13.6
   intl: ^0.18.1
   flutter_secure_storage: ^5.0.2
   provider: ^6.0.5


### PR DESCRIPTION
## Summary
- downgrade the http dependency to ^0.13.6 to ensure compatibility with Dart 2 SDK constraints

## Testing
- not run (fvm not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d31877e73083299cdff8b7b0b2e325