### PR TITLE
Remove ForceRedraw from Windows runner

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -31,11 +31,6 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
-  // Flutter can complete the first frame before the "show window" callback is
-  // registered. The following call ensures a frame is pending to ensure the
-  // window is shown. It is a no-op if the first frame hasn't completed yet.
-  flutter_controller_->ForceRedraw();
-
   return true;
 }
 


### PR DESCRIPTION
## Summary
- recreate the Windows runner without the newer ForceRedraw call to align with Flutter 3.7.12 scaffolding
- retain the existing window configuration and plugin wiring

## Testing
- unable to run `fvm flutter run -d windows` because the Flutter and FVM toolchains are not available in the execution environment (HTTP 403 when attempting to download)


------
https://chatgpt.com/codex/tasks/task_e_68d3220cded08329b65eb28ff5197f4b