### PR TITLE
Schedule Windows runner frame after startup

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -31,6 +31,8 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  flutter_controller_->engine()->ScheduleFrame();
+
   return true;
 }
 


### PR DESCRIPTION
## Summary
- schedule a frame from the Windows runner instead of relying on the removed `ForceRedraw` API
- keep the window-show callback so the first Flutter frame still reveals the window

## Testing
- `flutter test` *(fails: flutter tool not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d416de24a0832989f09ab794870b4c