### PR TITLE
Improve networking robustness and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,18 @@ El ejecutable se generará en `build\windows\runner\Release\`. Puedes comprimir 
 - [Guía de estilo de Dart](https://dart.dev/guides/language/effective-dart/style)
 - [Canal de YouTube Flutter](https://www.youtube.com/c/flutterdev)
 
+## Optimización de networking y caché
+Las consultas de visitas ahora están protegidas con varias capas de robustez para evitar saturar el servidor y ofrecer respuestas rápidas:
+
+- **Throttle y coalescing**: cada endpoint comparte un `Future` en vuelo y respeta un mínimo de 10 segundos entre actualizaciones automáticas, evitando ráfagas de peticiones.
+- **Caché en memoria con TTL y stale-while-revalidate**: los datos se sirven inmediatamente desde caché (TTL configurable) mientras se revalidan en segundo plano cuando es necesario.
+- **ETag/If-Modified-Since opcional**: se guardan los encabezados `ETag` y `Last-Modified` por URL y se envían en cada solicitud para aprovechar respuestas `304 Not Modified` cuando el servidor no ha cambiado.
+- **Límite de concurrencia global**: el cliente sólo sostiene dos solicitudes simultáneas, previniendo la saturación del backend.
+- **Botón "Actualizar"**: fuerza una actualización manual que omite throttle/TTL pero mantiene el coalescing y las validaciones condicionales.
+- **`bustUrl` para imágenes**: las fotos se cargan con un parámetro de versión (`?v=`) basado en `updatedAt` (o un timestamp) y encabezados `no-cache`, garantizando que los cambios se reflejen al instante sin parpadeos (`gaplessPlayback`).
+
+Los valores de intervalo de refresco automático, TTL y uso de ETag se pueden ajustar desde la pantalla de configuración.
+
 ---
 
 ¿Tienes dudas o quieres proponer una mejora? Abre un _issue_ o envía un _pull request_.

--- a/lib/src/screens/settings.dart
+++ b/lib/src/screens/settings.dart
@@ -17,6 +17,9 @@ class _SettingScreenState extends State<SettingScreen> {
   late bool _accesoVehicular, _accesoPeatonal, _accesoFacial /*, _accesoTag */;
   bool _guardando = false;
   final _prefs = UserPreferences();
+  late int _refreshIntervalSeconds;
+  late int _ttlSeconds;
+  late bool _useEtag;
 
   @override
   void initState() {
@@ -149,6 +152,82 @@ class _SettingScreenState extends State<SettingScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 30),
+        _networkingOptions(),
+      ],
+    );
+  }
+
+  Widget _networkingOptions() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Actualización automática',
+          style: TextStyle(fontSize: 25),
+        ),
+        const SizedBox(height: 10),
+        Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Intervalo (${_refreshIntervalSeconds}s)'),
+                  Slider(
+                    min: 5,
+                    max: 60,
+                    divisions: 11,
+                    label: '${_refreshIntervalSeconds}s',
+                    value: _refreshIntervalSeconds.toDouble(),
+                    onChanged: (double value) {
+                      setState(() {
+                        int newValue = value.round();
+                        if (newValue < 5) newValue = 5;
+                        if (newValue > 60) newValue = 60;
+                        _refreshIntervalSeconds = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('TTL caché (${_ttlSeconds}s)'),
+                  Slider(
+                    min: 15,
+                    max: 120,
+                    divisions: 21,
+                    label: '${_ttlSeconds}s',
+                    value: _ttlSeconds.toDouble(),
+                    onChanged: (double value) {
+                      setState(() {
+                        int newValue = value.round();
+                        if (newValue < 15) newValue = 15;
+                        if (newValue > 120) newValue = 120;
+                        _ttlSeconds = newValue;
+                      });
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        SwitchListTile(
+          contentPadding: EdgeInsets.zero,
+          title: const Text('Usar validaciones ETag/If-Modified-Since'),
+          value: _useEtag,
+          onChanged: (bool value) {
+            setState(() {
+              _useEtag = value;
+            });
+          },
+        ),
       ],
     );
   }
@@ -183,6 +262,9 @@ class _SettingScreenState extends State<SettingScreen> {
     _prefs.accesoVehicular = _accesoVehicular ? 1 : 0;
     _prefs.accesoPeatonal = _accesoPeatonal ? 1 : 0;
     _prefs.accesoFacial = _accesoFacial ? 1 : 0;
+    _prefs.refreshIntervalSeconds = _refreshIntervalSeconds;
+    _prefs.cacheTtlSeconds = _ttlSeconds;
+    _prefs.useEtag = _useEtag;
     //_prefs.accesoTag = _accesoTag ? 1 : 0;
 
     openAlertBoxSimple(
@@ -198,6 +280,9 @@ class _SettingScreenState extends State<SettingScreen> {
     _accesoVehicular = _prefs.accesoVehicular == 1;
     _accesoPeatonal = _prefs.accesoPeatonal == 1;
     _accesoFacial = _prefs.accesoFacial == 1;
+    _refreshIntervalSeconds = _prefs.refreshIntervalSeconds;
+    _ttlSeconds = _prefs.cacheTtlSeconds;
+    _useEtag = _prefs.useEtag;
     //_accesoTag = _prefs.accesoTag == 1;
   }
 }

--- a/lib/src/services/api_http_client.dart
+++ b/lib/src/services/api_http_client.dart
@@ -11,6 +11,8 @@ class ApiHttpClient {
 
   final http.Client _client;
   final SecurityContext _context;
+  final Map<String, String> _etagCache = <String, String>{};
+  final Map<String, String> _lastModifiedCache = <String, String>{};
 
   static ApiHttpClient? _instance;
 
@@ -24,6 +26,33 @@ class ApiHttpClient {
 
   http.Client get client => _client;
   SecurityContext get securityContext => _context;
+
+  /// Returns the cached ETag associated with [url], if any.
+  String? getEtag(String url) => _etagCache[url];
+
+  /// Stores or clears the cached ETag for [url].
+  void setEtag(String url, String? etag) {
+    if (etag == null || etag.isEmpty) {
+      _etagCache.remove(url);
+    } else {
+      _etagCache[url] = etag;
+    }
+  }
+
+  /// Returns the cached Last-Modified header associated with [url], if any.
+  String? getLastModified(String url) => _lastModifiedCache[url];
+
+  /// Stores or clears the cached Last-Modified header for [url].
+  void setLastModified(String url, String? value) {
+    if (value == null || value.isEmpty) {
+      _lastModifiedCache.remove(url);
+    } else {
+      _lastModifiedCache[url] = value;
+    }
+  }
+
+  /// Internal helper for tests to check if the client was initialised.
+  static ApiHttpClient? get maybeInstance => _instance;
 
   static Future<void> initialize(String certificateAssetPath) async {
     if (_instance != null) {

--- a/lib/src/services/visitService.dart
+++ b/lib/src/services/visitService.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer';
 
@@ -6,10 +8,10 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_dostop_monitoreo/src/utils/utils.dart';
 import 'package:http/http.dart' as http;
 
+import '../utils/user_preferences.dart';
 import 'api_http_client.dart';
 
 class VisitService extends ChangeNotifier {
-  //final String _baseUrl = '192.168.100.7';
   final String _prod = 'dostop.mx';
 
   VisitService({http.Client? client}) : _client = client ?? ApiHttpClient.instance.client;
@@ -17,124 +19,419 @@ class VisitService extends ChangeNotifier {
   final http.Client _client;
 
   final _storage = const FlutterSecureStorage();
+  final UserPreferences _prefs = UserPreferences();
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
-  //final tok =      'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6IjMiLCJpZEZyYWNjaW9uYW1pZW50byI6IjEiLCJ1c2VybmFtZSI6Imd1YXJkaWFkZW1vIn0.BkCJkrxR_YYG72ODCw5k8BTM7kBQbNWBdsSAg7I7jao';
+  final Map<String, Future<_NetworkResult>> _inflight = <String, Future<_NetworkResult>>{};
+  final Map<String, DateTime> _lastHit = <String, DateTime>{};
+  final Map<String, _CacheEntry> _cache = <String, _CacheEntry>{};
+  final _SimpleSemaphore _semaphore = _SimpleSemaphore(2);
 
-  Future<Map<String, dynamic>> ultimaVisitaVehicular() async {
-    final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
-    };
+  Duration get _ttlDuration {
+    final ttlSeconds = _prefs.cacheTtlSeconds.clamp(15, 120);
+    return Duration(seconds: ttlSeconds);
+  }
 
+  Duration get _throttleDuration {
+    final refreshSeconds = _prefs.refreshIntervalSeconds.clamp(5, 60);
+    return Duration(seconds: refreshSeconds < 10 ? 10 : refreshSeconds);
+  }
+
+  ApiHttpClient? get _apiClient {
     try {
-      final url = Uri.https(_prod, '/api/AppGuardias/mVisitaVehicular');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
-
-      return decodeResp;
-    } catch (e) {
-      log('error visita vehicular: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+      return ApiHttpClient.instance;
+    } catch (_) {
+      return ApiHttpClient.maybeInstance;
     }
   }
 
-  Future<Map<String, dynamic>> ultimaSalidaVehicular() async {
+  Future<Map<String, dynamic>> ultimaVisitaVehicular({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaVisitaVehicular',
+      uri: Uri.https(_prod, '/api/AppGuardias/mVisitaVehicular'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> ultimaSalidaVehicular({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaSalidaVehicular',
+      uri: Uri.https(_prod, '/api/AppGuardias/mSalidaVehicular'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> ultimaVisitaPeatonal({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaVisitaPeatonal',
+      uri: Uri.https(_prod, '/api/AppGuardias/mVisitaPeatonal'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> ultimaSalidaPeatonal({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaSalidaPeatonal',
+      uri: Uri.https(_prod, '/api/AppGuardias/mSalidaPeatonal'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> ultimaVisitafacial({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaVisitaFacial',
+      uri: Uri.https(_prod, '/api/AppGuardias/ultimaVisitaFacial'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> ultimaSalidaFacial({bool forceRefresh = false}) async {
+    return _getWithLogs(
+      label: 'ultimaSalidaFacial',
+      uri: Uri.https(_prod, '/api/AppGuardias/ultimaSalidaFacial'),
+      forceRefresh: forceRefresh,
+    );
+  }
+
+  Future<Map<String, dynamic>> _getWithLogs({
+    required String label,
+    required Uri uri,
+    required bool forceRefresh,
+  }) async {
     final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
+    final headers = <String, String>{
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
+      'Authorization': 'Bearer $token',
     };
 
-    try {
-      final url = Uri.https(_prod, '/api/AppGuardias/mSalidaVehicular');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
+    final String cacheKey = uri.toString();
+    final Duration ttl = _ttlDuration;
+    final DateTime now = DateTime.now();
+    final _CacheEntry? cachedEntry = _cache[cacheKey];
 
-      return decodeResp;
-    } catch (e) {
-      log('error salida vehicular: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+    if (!forceRefresh && cachedEntry != null && cachedEntry.isFresh(ttl)) {
+      _lastHit[cacheKey] = now;
+      _scheduleRevalidateIfNeeded(cacheKey, uri, headers, label);
+      _logRequest(
+        label,
+        coalesced: false,
+        throttled: false,
+        fromCache: true,
+        ttl: ttl,
+        etagSent: false,
+        got304: false,
+        statusCode: cachedEntry.statusCode,
+      );
+      return cachedEntry.body;
+    }
+
+    bool throttled = false;
+    if (!forceRefresh) {
+      final DateTime? last = _lastHit[cacheKey];
+      if (last != null && now.difference(last) < _throttleDuration) {
+        throttled = true;
+        if (cachedEntry != null) {
+          _lastHit[cacheKey] = now;
+          _logRequest(
+            label,
+            coalesced: false,
+            throttled: true,
+            fromCache: true,
+            ttl: ttl,
+            etagSent: false,
+            got304: false,
+            statusCode: cachedEntry.statusCode,
+          );
+          return cachedEntry.body;
+        }
+      }
+    }
+
+    Future<_NetworkResult>? requestFuture = _inflight[cacheKey];
+    bool coalesced = false;
+    if (requestFuture != null) {
+      coalesced = true;
+    } else {
+      requestFuture = _executeRequest(
+        cacheKey,
+        uri,
+        headers,
+        label,
+        useConditionalRequests: _prefs.useEtag,
+      );
+      _inflight[cacheKey] = requestFuture;
+    }
+
+    try {
+      final _NetworkResult result = await requestFuture!;
+      if (identical(_inflight[cacheKey], requestFuture)) {
+        _inflight.remove(cacheKey);
+      }
+      final _CacheEntry? entry = result.cacheEntry;
+      if (entry != null) {
+        _cache[cacheKey] = entry;
+      }
+      _lastHit[cacheKey] = DateTime.now();
+      _logRequest(
+        label,
+        coalesced: coalesced,
+        throttled: throttled,
+        fromCache: result.fromCache,
+        ttl: ttl,
+        etagSent: result.etagSent,
+        got304: result.got304,
+        statusCode: result.statusCode,
+      );
+      return result.body;
+    } catch (error, stackTrace) {
+      if (identical(_inflight[cacheKey], requestFuture)) {
+        _inflight.remove(cacheKey);
+      }
+      log('[VisitService] $label request error: $error', stackTrace: stackTrace);
+      return <String, dynamic>{
+        'statusCode': 0,
+        'status': 'error',
+        'message': messageError(error),
+      };
     }
   }
 
-  Future<Map<String, dynamic>> ultimaVisitaPeatonal() async {
-    final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
-    };
+  void _scheduleRevalidateIfNeeded(
+    String cacheKey,
+    Uri uri,
+    Map<String, String> headers,
+    String label,
+  ) {
+    if (_inflight.containsKey(cacheKey)) {
+      return;
+    }
+    final Future<_NetworkResult> future = _executeRequest(
+      cacheKey,
+      uri,
+      headers,
+      label,
+      useConditionalRequests: _prefs.useEtag,
+    );
+    _inflight[cacheKey] = future;
+    future.then((result) {
+      if (result.cacheEntry != null) {
+        _cache[cacheKey] = result.cacheEntry!;
+      }
+      _lastHit[cacheKey] = DateTime.now();
+      _logRequest(
+        label,
+        coalesced: false,
+        throttled: false,
+        fromCache: result.fromCache,
+        ttl: _ttlDuration,
+        etagSent: result.etagSent,
+        got304: result.got304,
+        statusCode: result.statusCode,
+        background: true,
+      );
+    }).catchError((Object error, StackTrace stackTrace) {
+      log('[VisitService] $label background revalidation error: $error', stackTrace: stackTrace);
+    }).whenComplete(() {
+      if (identical(_inflight[cacheKey], future)) {
+        _inflight.remove(cacheKey);
+      }
+    });
+  }
 
+  Future<_NetworkResult> _executeRequest(
+    String cacheKey,
+    Uri uri,
+    Map<String, String> headers,
+    String label, {
+    required bool useConditionalRequests,
+  }) {
+    return _semaphore.withPermit(() async {
+      final Map<String, String> requestHeaders = Map<String, String>.from(headers);
+      bool conditionalSent = false;
+      final ApiHttpClient? apiClient = useConditionalRequests ? _apiClient : null;
+
+      if (apiClient != null) {
+        final String? etag = apiClient.getEtag(cacheKey);
+        if (etag != null && etag.isNotEmpty) {
+          requestHeaders['If-None-Match'] = etag;
+          conditionalSent = true;
+        }
+        final String? lastModified = apiClient.getLastModified(cacheKey);
+        if (lastModified != null && lastModified.isNotEmpty) {
+          requestHeaders['If-Modified-Since'] = lastModified;
+          conditionalSent = true;
+        }
+      }
+
+      final http.Response response = await _client.get(uri, headers: requestHeaders);
+      final Map<String, String> responseHeaders = Map<String, String>.from(response.headers);
+
+      if (apiClient != null) {
+        final String? newEtag = responseHeaders['etag'];
+        if (newEtag != null && newEtag.isNotEmpty) {
+          apiClient.setEtag(cacheKey, newEtag);
+        }
+        final String? newLastModified = responseHeaders['last-modified'];
+        if (newLastModified != null && newLastModified.isNotEmpty) {
+          apiClient.setLastModified(cacheKey, newLastModified);
+        }
+      }
+
+      if (response.statusCode == 304) {
+        final _CacheEntry? cacheEntry = _cache[cacheKey];
+        if (cacheEntry != null) {
+          final _CacheEntry refreshedEntry = cacheEntry.refreshed();
+          return _NetworkResult(
+            body: refreshedEntry.body,
+            cacheEntry: refreshedEntry,
+            fromCache: true,
+            etagSent: conditionalSent,
+            got304: true,
+            statusCode: cacheEntry.statusCode,
+          );
+        }
+        log('[VisitService] $label received 304 without cache for $cacheKey');
+        return _NetworkResult(
+          body: <String, dynamic>{'statusCode': response.statusCode},
+          cacheEntry: null,
+          fromCache: true,
+          etagSent: conditionalSent,
+          got304: true,
+          statusCode: response.statusCode,
+        );
+      }
+
+      final Map<String, dynamic> decodedBody = _parseBody(response.body);
+      final _CacheEntry entry = _CacheEntry(
+        body: decodedBody,
+        statusCode: response.statusCode,
+        headers: responseHeaders,
+        timestamp: DateTime.now(),
+      );
+
+      return _NetworkResult(
+        body: decodedBody,
+        cacheEntry: entry,
+        fromCache: false,
+        etagSent: conditionalSent,
+        got304: false,
+        statusCode: response.statusCode,
+      );
+    });
+  }
+
+  Map<String, dynamic> _parseBody(String body) {
+    if (body.isEmpty) {
+      return <String, dynamic>{};
+    }
     try {
-      final url = Uri.https(_prod, '/api/AppGuardias/mVisitaPeatonal');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
-
-      return decodeResp;
+      final dynamic decoded = json.decode(body);
+      if (decoded is Map<String, dynamic>) {
+        return decoded;
+      }
+      return <String, dynamic>{'data': decoded};
     } catch (e) {
-      log('error entrada peatonal: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+      log('[VisitService] Failed to decode response body: $e');
+      return <String, dynamic>{'raw': body};
     }
   }
 
-  Future<Map<String, dynamic>> ultimaSalidaPeatonal() async {
-    final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
-    };
+  void _logRequest(
+    String label, {
+    required bool coalesced,
+    required bool throttled,
+    required bool fromCache,
+    required Duration ttl,
+    required bool etagSent,
+    required bool got304,
+    int? statusCode,
+    bool background = false,
+  }) {
+    final String backgroundText = background ? ' background=true' : '';
+    log('[VisitService] $label coalesced=$coalesced throttled=$throttled fromCache=$fromCache ttl=${ttl.inSeconds}s etagSent=$etagSent got304=$got304 statusCode=${statusCode ?? '-'}$backgroundText');
+  }
+}
 
+class _CacheEntry {
+  _CacheEntry({
+    required this.body,
+    required this.statusCode,
+    required this.headers,
+    required this.timestamp,
+  });
+
+  final Map<String, dynamic> body;
+  final int statusCode;
+  final Map<String, String> headers;
+  final DateTime timestamp;
+
+  bool isFresh(Duration ttl) => DateTime.now().difference(timestamp) < ttl;
+
+  _CacheEntry refreshed() {
+    return _CacheEntry(
+      body: body,
+      statusCode: statusCode,
+      headers: headers,
+      timestamp: DateTime.now(),
+    );
+  }
+}
+
+class _NetworkResult {
+  _NetworkResult({
+    required this.body,
+    required this.cacheEntry,
+    required this.fromCache,
+    required this.etagSent,
+    required this.got304,
+    required this.statusCode,
+  });
+
+  final Map<String, dynamic> body;
+  final _CacheEntry? cacheEntry;
+  final bool fromCache;
+  final bool etagSent;
+  final bool got304;
+  final int statusCode;
+}
+
+class _SimpleSemaphore {
+  _SimpleSemaphore(this._maxConcurrent);
+
+  final int _maxConcurrent;
+  int _current = 0;
+  final Queue<Completer<void>> _waiters = Queue<Completer<void>>();
+
+  Future<T> withPermit<T>(Future<T> Function() action) async {
+    await _acquire();
     try {
-      final url = Uri.https(_prod, '/api/AppGuardias/mSalidaPeatonal');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
-      return decodeResp;
-    } catch (e) {
-      log('error salida peatonal: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+      return await action();
+    } finally {
+      _release();
     }
   }
 
-  Future<Map<String, dynamic>> ultimaVisitafacial() async {
-    final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
-    };
-
-    try {
-      final url = Uri.https(_prod, '/api/AppGuardias/ultimaVisitaFacial');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
-      return decodeResp;
-    } catch (e) {
-      log('error visita facial: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+  Future<void> _acquire() {
+    if (_current < _maxConcurrent) {
+      _current++;
+      return Future<void>.value();
     }
+    final Completer<void> completer = Completer<void>();
+    _waiters.add(completer);
+    return completer.future.then((_) {
+      _current++;
+    });
   }
 
-  Future<Map<String, dynamic>> ultimaSalidaFacial() async {
-    final token = await _storage.read(key: 'token') ?? '';
-    final Map<String, String> headers = {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + token.toString()
-      //'Authorization': 'Bearer ' + tok
-    };
-
-    try {
-      final url = Uri.https(_prod, '/api/AppGuardias/ultimaSalidaFacial');
-      final resp = await _client.get(url, headers: headers);
-      final Map<String, dynamic> decodeResp = json.decode(resp.body);
-      return decodeResp;
-    } catch (e) {
-      log('error salida facial: $e');
-      return {'statusCode': 0, 'status': 'error', 'message': messageError(e)};
+  void _release() {
+    if (_current > 0) {
+      _current--;
+    }
+    if (_waiters.isNotEmpty) {
+      final Completer<void> completer = _waiters.removeFirst();
+      if (!completer.isCompleted) {
+        completer.complete();
+      }
     }
   }
 }

--- a/lib/src/utils/user_preferences.dart
+++ b/lib/src/utils/user_preferences.dart
@@ -58,6 +58,32 @@ class UserPreferences with ChangeNotifier {
     return _prefs.getInt('accesoFacial') ?? 1;
   }
 
+  int get refreshIntervalSeconds {
+    return _prefs.getInt('refreshIntervalSeconds') ?? 10;
+  }
+
+  set refreshIntervalSeconds(int value) {
+    final int safeValue = value.clamp(5, 60).toInt();
+    _prefs.setInt('refreshIntervalSeconds', safeValue);
+  }
+
+  int get cacheTtlSeconds {
+    return _prefs.getInt('cacheTtlSeconds') ?? 30;
+  }
+
+  set cacheTtlSeconds(int value) {
+    final int safeValue = value.clamp(15, 120).toInt();
+    _prefs.setInt('cacheTtlSeconds', safeValue);
+  }
+
+  bool get useEtag {
+    return _prefs.getBool('useEtag') ?? true;
+  }
+
+  set useEtag(bool value) {
+    _prefs.setBool('useEtag', value);
+  }
+
   /* set accesoTag(int value) {
     _prefs.setInt('accesoTag', value);
   }


### PR DESCRIPTION
## Summary
- add in-memory caching, request throttling/coalescing, conditional headers, and concurrency limits to the visit service
- enhance the home screen with lifecycle-aware refresh timers, manual refresh, and cache-busting image loading
- expose refresh/TTL/ETag preferences in settings and document the networking safeguards in the README

## Testing
- not run (flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6bfb2bc5083299ad32131c9e7175e