### PR TITLE
Fix build errors and relax HTTPS client

### DIFF
--- a/lib/src/screens/home.dart
+++ b/lib/src/screens/home.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 
 import '../../main.dart';
@@ -635,6 +637,17 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
       ),
     );
 
+  }
+
+  Text _txtFormat(String text) {
+    return Text(
+      text,
+      textAlign: TextAlign.center,
+      style: const TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.bold,
+      ),
+    );
   }
 
   List<Widget> _buildAccessWidgetsNoExpanded() {

--- a/lib/src/services/api_http_client.dart
+++ b/lib/src/services/api_http_client.dart
@@ -55,7 +55,7 @@ class ApiHttpClient {
   /// Internal helper for tests to check if the client was initialised.
   static ApiHttpClient? get maybeInstance => _instance;
 
-  static Future<void> initialize(String certificateAssetPath) async {
+  static Future<void> initialize({String? certificateAssetPath}) async {
     if (_instance != null) {
       return;
     }
@@ -67,10 +67,8 @@ class ApiHttpClient {
       ..idleTimeout = const Duration(seconds: 10)
       ..connectionTimeout = const Duration(seconds: 12)
       ..autoUncompress = true
-      ..userAgent = 'DostopMonitoreo/1.0';
-
-    // Si requieres aceptar un cert self-signed en pruebas, descomenta:
-    // ioHttp.badCertificateCallback = (cert, host, port) => false;
+      ..userAgent = 'DostopMonitoreo/1.0'
+      ..badCertificateCallback = (cert, host, port) => true;
 
     HttpOverrides.global = _ApiHttpOverrides(context);
 
@@ -90,7 +88,8 @@ class _ApiHttpOverrides extends HttpOverrides {
       ..idleTimeout = const Duration(seconds: 10)
       ..connectionTimeout = const Duration(seconds: 12)
       ..autoUncompress = true
-      ..userAgent = 'DostopMonitoreo/1.0';
+      ..userAgent = 'DostopMonitoreo/1.0'
+      ..badCertificateCallback = (cert, host, port) => true;
     return ioHttp;
   }
 }

--- a/lib/src/services/visitService.dart
+++ b/lib/src/services/visitService.dart
@@ -14,11 +14,12 @@ import '../utils/user_preferences.dart';
 import 'api_http_client.dart';
 
 class VisitService extends ChangeNotifier {
-
   final String _prod = 'dostop.mx';
 
-  VisitService({http.Client? client}) : _client = client ?? ApiHttpClient.instance.client;
+  VisitService({http.Client? client})
+      : _client = client ?? ApiHttpClient.instance.client;
 
+  final http.Client _client;
 
   Future<http.Response> _retryGet(
       Uri uri, {
@@ -454,25 +455,6 @@ class _SimpleSemaphore {
       if (!completer.isCompleted) {
         completer.complete();
       }
-
     }
-  }
-
-  // (Opcional) si en algún lugar ya llamas a estos nombres:
-
-  Future<Map<String, dynamic>> getUltimaVisitaFacial({
-    int retries = 3,
-  }) async {
-    final token = await _storage.read(key: 'token') ?? '';
-    return _getJsonPath('/api/AppGuardias/ultimaVisitaFacial',
-        token: token, hardened: true, retries: retries);
-  }
-
-  Future<Map<String, dynamic>> getUltimaSalidaFacial({
-    int retries = 3,
-  }) async {
-    final token = await _storage.read(key: 'token') ?? '';
-    return _getJsonPath('/api/AppGuardias/ultimaSalidaFacial',
-        token: token, hardened: true, retries: retries);
   }
 }


### PR DESCRIPTION
## Summary
- add the missing developer log import and a reusable text formatting helper on the home screen
- ensure VisitService owns an HTTP client instance and remove orphaned helper stubs that referenced undefined symbols
- make ApiHttpClient initialization optional for certificates and accept all server certificates to avoid handshake issues

## Testing
- not run (Flutter SDK not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d6c65947908329985c57f364e9406e