### PR TITLE
Fix HttpOverrides client creation

### DIFF
--- a/lib/src/services/api_http_client.dart
+++ b/lib/src/services/api_http_client.dart
@@ -83,8 +83,8 @@ class _ApiHttpOverrides extends HttpOverrides {
   final SecurityContext context;
 
   @override
-  HttpClient createHttpClient(SecurityContext? _) {
-    final ioHttp = HttpClient(context: context)
+  HttpClient createHttpClient(SecurityContext? overrideContext) {
+    final ioHttp = super.createHttpClient(overrideContext ?? context)
       ..idleTimeout = const Duration(seconds: 10)
       ..connectionTimeout = const Duration(seconds: 12)
       ..autoUncompress = true


### PR DESCRIPTION
## Summary
- construct the HTTP client in ApiHttpClient overrides using the base implementation
- keep the existing timeout, compression, user agent, and certificate callback configuration

## Testing
- flutter test *(fails: flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f8440d1c8329abeba09a67f4c0a6